### PR TITLE
Actions: Reduce permissions for workflow jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions: {}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,6 +84,8 @@ jobs:
     needs: bump-version
 
     runs-on: ${{ matrix.os }}
+
+    permissions: {}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
💁 These changes reduce the permissions used by the GitHub Actions workflows to a functional minimum to follow a least privilege stance.