### PR TITLE
Indent the `mkdocs` section correctly

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 version: "2"
-
+    
 build:
   os: "ubuntu-24.04"
   tools:
@@ -10,5 +10,5 @@ build:
       - pip install poetry
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
-  mkdocs:
-    configuration: mkdocs.yml
+mkdocs:
+  configuration: mkdocs.yml


### PR DESCRIPTION
💁 This change moves the `mkdocs` section to the correct location, as per the [JSON schema used for this config file](https://github.com/readthedocs/readthedocs.org/blob/1d50bb7dbf3d9bd9efd878dea93e1373033a7f50/readthedocs/rtd_tests/fixtures/spec/v2/schema.json).