### PR TITLE
Build releases automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Release Please
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+          release-type: python


### PR DESCRIPTION
💁 These changes add a release workflow job to build releases automatically using [googleapis/release-please-action](https://github.com/googleapis/release-please-action).