### PR TITLE
chore(ci): Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [ published ]
 
+permissions: {}
+
 env:
   POETRY_VERSION: "2.1.3"
   POETRY_CORE_VERSION: "2.1.3"
@@ -14,8 +16,6 @@ jobs:
     name: Build sdist
 
     runs-on: ubuntu-latest
-
-    permissions: {}
 
     steps:
       - name: Checkout code
@@ -50,8 +50,6 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
-
-    permissions: {}
 
     strategy:
       fail-fast: false
@@ -104,6 +102,7 @@ jobs:
       url: https://test.pypi.org/p/quart-assets
 
     permissions:
+      contents: read
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
 
@@ -134,6 +133,7 @@ jobs:
       url: https://pypi.org/p/quart-assets
 
     permissions:
+      contents: read
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
 


### PR DESCRIPTION
💁 The publish workflow job needs to be updated after adding the release workflow in #23. These changes:
- [x] Remove the `bump-release` job in favour of the Release Please action in `release.yml`.
- [x] Move job permissions to the workflow level.