### PR TITLE
Dependabot: configure cooldowns, group updates, switch ecosystem to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,30 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
-      prefix: "fix"
-      include: "scope"
-  - package-ecosystem: "pip"
-    directory: "/"
+      prefix: ci
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: uv
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      include: "scope"
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      python:
+        patterns:
+          - "*"


### PR DESCRIPTION
💁‍♂️ These changes update the Dependabot configuration to:
- switch the package ecosystem to uv (missed in #99)
- group updates, including security patches
- add cooldown periods