### PR TITLE
ci(deps): Limit uv updates to direct deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,11 +21,18 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: direct
     commit-message:
       prefix: fix
       prefix-development: chore
       include: scope
     groups:
+      python-development:
+        dependency-type: development
+        patterns:
+          - "*"
       python:
+        dependency-type: production
         patterns:
           - "*"


### PR DESCRIPTION
:tipping_hand_person: These changes restrict Dependabot's uv updates to direct dependencies and split the group by dependency type.

## Why

Dependabot's uv parser classifies transitive entries in `uv.lock` as *production*, no matter which `[dependency-groups]` entry pulled them in. That produced misleading commit prefixes:

- `fix(deps): Bump pymdown-extensions` — only reachable from `mkdocs-material` / `mkdocstrings` (docs group)
- `fix(deps): Bump uv` — only reachable from `tox-uv` (dev group)

A `fix(deps)` commit tells release-please to cut a patch release, so docs tooling bumps were triggering releases of the published package.

The existing `python` group also had no `dependency-type`, so Dependabot silently split it into a development PR and a production PR. The production side was frequently a single dependency, which is why those PRs looked ungrouped.

## What changed

- `allow: dependency-type: direct` — only direct dependencies get version-update PRs. Every remaining PR is then classified correctly: runtime deps (`quart`, `webassets`, `pyscss`, `pyyaml`) get `fix(deps)`, and everything in the `test` / `dev` / `docs` groups gets `chore(deps-dev)`.
- Two explicit groups, `python-development` and `python`, each pinned to a `dependency-type`. This makes the existing implicit split deliberate: at most two PRs per week, no single-dependency stragglers.

## Trade-offs

Lockfile transitives now drift until a direct dependency forces a re-resolve. Security updates are unaffected — Dependabot security PRs ignore `allow`, so vulnerable transitives such as `h2` still get raised.
