### PR TITLE
build: support Python 3.14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   build-sdist:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install dev dependencies
         run: uv sync --group dev
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.13
+  python: python3.14
 
 default_install_hook_types: [pre-commit, pre-push, commit-msg]
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: "2"
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "3.13"
+    python: "3.14"
 
   jobs:
     install:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ quart assets watch
 - **Entry point**: `pyproject.toml` defines `quart.commands` entry point for CLI integration
 - **Version**: Managed via `__version__` string in `src/quart_assets/__init__.py`
 - **Dependencies**: Core deps are `quart>=0.20.0,<0.21.0` and `webassets>=2.0`
-- **Python support**: 3.10, 3.11, 3.12, 3.13 (defined in `pyproject.toml` under `[tool.tox]` and `[project]`)
+- **Python support**: 3.10, 3.11, 3.12, 3.13, 3.14 (defined in `pyproject.toml` under `[tool.tox]` and `[project]`)
 
 ## Notable Implementation Details
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,12 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
@@ -101,7 +107,7 @@ addopts = "--showlocals --strict-markers"
 testpaths = ["tests"]
 
 [tool.tox]
-env_list = ["lint", "py3{10,11,12,13}", "types", "package", "report"]
+env_list = ["lint", "py3{10,11,12,13,14}", "types", "package", "report"]
 skip_missing_interpreters = true
 runner = "uv-venv-lock-runner"
 
@@ -111,6 +117,7 @@ python = """
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
     """
 
 [tool.tox.env_run_base]
@@ -118,7 +125,7 @@ dependency_groups = ["test"]
 commands = [["pytest", "--cov", "--cov-append", "{posargs}"]]
 
 [tool.tox.env.lint]
-base_python = "python3.13"
+base_python = "python3.14"
 deps = ["ruff"]
 skip_install = true
 commands = [
@@ -127,7 +134,7 @@ commands = [
 ]
 
 [tool.tox.env.report]
-base_python = "python3.13"
+base_python = "python3.14"
 deps = ["coverage"]
 skip_install = true
 commands = [
@@ -136,12 +143,12 @@ commands = [
 ]
 
 [tool.tox.env.types]
-base_python = "python3.13"
+base_python = "python3.14"
 deps = ["ty", "pytest"]
 commands = [["ty", "check"]]
 
 [tool.tox.env.package]
-base_python = "python3.13"
+base_python = "python3.14"
 allowlist_externals = ["uv"]
 deps = ["twine"]
 commands = [

--- a/uv.lock
+++ b/uv.lock
@@ -1064,7 +1064,7 @@ wheels = [
 
 [[package]]
 name = "quart-assets"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "pyscss" },


### PR DESCRIPTION
:tipping_hand_person: These changes add Python 3.14 to the supported versions and move the pinned tooling interpreter from 3.13 to 3.14.

## What changed

- `pyproject.toml`: `py314` added to the tox `env_list` and the `gh-actions` mapping; the `lint`, `types`, `report` and `package` tox envs now use `python3.14`; added `Programming Language :: Python` trove classifiers for 3.10 through 3.14.
- `.github/workflows/tests.yml`: `3.14` added to the test matrix, and the pre-commit job now runs on 3.14.
- `.github/workflows/publish.yml`: `PYTHON_VERSION` is now `3.14`.
- `.pre-commit-config.yaml`: `default_language_version` is now `python3.14`.
- `.readthedocs.yml`: docs build now uses 3.14.
- `CLAUDE.md`: supported versions list updated.
- `uv.lock`: refreshed. It was stale from the 0.1.7 release and `uv lock --check` failed until it was updated.

`requires-python` stays at `>=3.10` and ruff `target-version` stays at `py310`, since both track the lowest supported version rather than the highest.

## Testing

Run locally on 3.14:

- `tox -e py314,lint,types` — 30 passed, 99% coverage, ruff clean, ty clean.
- `tox -e package` — builds the sdist and wheel, `twine check` passed.
- `pre-commit run --all-files` — all hooks passed.

One thing to watch: `pyscss` 1.4.0 installs on 3.14 as a pure-Python fallback locally. If a matrix platform needs its C speedups compiled and no 3.14 wheel exists, the Windows and macOS jobs will show it.